### PR TITLE
Add batch mode and Dockerfile for running as a container

### DIFF
--- a/Dockerfile.support
+++ b/Dockerfile.support
@@ -1,0 +1,16 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && apt-get install -y curl
+
+ADD https://get.docker.com/builds/Linux/x86_64/docker-1.7.0 /usr/local/bin/docker
+RUN chmod +x /usr/local/bin/docker
+
+ADD https://raw.githubusercontent.com/docker/docker/master/contrib/check-config.sh /check-config.sh
+RUN chmod +x /check-config.sh
+
+ADD dsinfo.sh /dsinfo.sh
+RUN chmod +x /dsinfo.sh
+
+ENV TAG latest
+
+CMD /dsinfo.sh -b 2>/dev/null


### PR DESCRIPTION
This change adds getopt support for changing various command line
args, and also adds a new "batch" mode which runs everything and
spits it out in base64 to stdout.  This can be used in a container
(with included Dockerfile), although with the caveat that it can't
restart the Docker daemon.

I've been running it with the command:

$ docker run -it --rm -v /boot:/boot -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker:/var/lib/docker -v /var/log:/var/log -v /etc/sysconfig:/etc/sysconfig -v /etc/default:/etc/default pdevine/dsinfo:latest > foo.base64

Signed-off-by: Patrick Devine <patrick.devine@docker.com>