### PR TITLE
Add more dsinfo output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM alpine:3.2
 
-ADD https://get.docker.com/builds/Linux/x86_64/docker-1.7.0 /usr/local/bin/docker
+ENV DOCKER_VERSION 1.9.1
+
+RUN apk update && \
+    apk fetch procps sysstat dmidecode && \
+    apk add procps sysstat dmidecode
+
+ADD https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION} /usr/local/bin/docker
 RUN chmod +x /usr/local/bin/docker
 
 ADD https://raw.githubusercontent.com/docker/docker/master/contrib/check-config.sh /check-config.sh

--- a/dsinfo.sh
+++ b/dsinfo.sh
@@ -259,7 +259,11 @@ header 'System Info'
 bline
 
 execute 'hostname'
-execute 'cat /etc/*release'
+if [ $BATCH = false ]; then
+  execute 'cat /etc/*release'
+else
+  execute 'cat /etc_host/*release'
+fi
 execute 'cat /proc/version'
 execute 'cat /proc/cpuinfo'
 execute 'cat /proc/meminfo'
@@ -267,11 +271,16 @@ execute 'cat /proc/cgroups'
 execute 'cat /proc/self/cgroup'
 execute 'df -h'
 execute 'mount'
-execute 'ifconfig'
-execute 'ps aux | grep docker'
-execute 'netstat -npl'
-execute 'sestatus'
+if [ $BATCH = false ]; then
+  execute 'ifconfig'
+  execute 'ps aux | grep docker'
+  execute 'netstat -npl'
+  execute 'sestatus'
+fi
+execute 'vmstat 1 5'
+execute 'iostat 1 5'
 execute 'dmidecode'
+
 
 # tar
 BASEDIR=`basename $TD`


### PR DESCRIPTION
This change adds support for dmidecode to work inside of the container,
as well as gets addition stats which may help with debugging.

Signed-off-by: Patrick Devine <patrick.devine@docker.com>