### PR TITLE
Capture stderr and stdout from logs

### DIFF
--- a/dsinfo.sh
+++ b/dsinfo.sh
@@ -227,7 +227,7 @@ esac
 
 # inspect, logs
 for container in $(docker ps -a -n 20 -q); do
-  docker logs ${container} | tail -n ${LOGLINES} >> ${TD}/logs/${container}.log
+  docker logs 2>&1 ${container} | tail -n ${LOGLINES} >> ${TD}/logs/${container}.log
   docker inspect ${container} >> ${TD}/inspect/${container}.txt
 done
 


### PR DESCRIPTION
dsinfo was only capturing stdout from containers which meant
many services which log to stderr had their output dropped.